### PR TITLE
index.js: retain user input order in package list

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -615,7 +615,6 @@ function updateImages(mobj) {
       $("#asu-packages").value = mobj.default_packages
         .concat(mobj.device_packages)
         .concat(config.asu_extra_packages || [])
-        .sort()
         .join(" ");
     }
 


### PR DESCRIPTION
This allows users to work around an opkg bug that causes package installation failure when the package list is sorted.  For one specific example, see https://forum.openwrt.org/t/owut-openwrt-upgrade-tool/200035/61.

Depends on asu commit openwrt/asu@b7c8a4263d

Signed-off-by: Eric Fahlgren <ericfahlgren@gmail.com>