### PR TITLE
asu: device and default package input

### DIFF
--- a/www/index.css
+++ b/www/index.css
@@ -353,7 +353,8 @@ header > div {
   overflow: scroll;
 }
 
-#asu-packages,
+#asu-device-packages,
+#asu-default-packages,
 #uci-defaults-content,
 #uci-defaults-group {
   resize: none;

--- a/www/index.html
+++ b/www/index.html
@@ -153,14 +153,9 @@
                   </div>
                 </div>
                 <div>
-                  <h5 class="tr-packages">Installed Packages</h5>
-                  <textarea
-                    rows="10"
-                    id="asu-packages"
-                    autocomplete="off"
-                    spellcheck="false"
-                    autocapitalize="off"
-                  ></textarea>
+                  <h5 class="tr-packages">Install Packages</h5>
+                  <textarea rows="2" id="asu-device-packages"></textarea>
+                  <textarea rows="7" id="asu-default-packages"></textarea>
                 </div>
                 <h5 class="tr-defaults">
                   Script to run on first boot (uci-defaults)

--- a/www/index.js
+++ b/www/index.js
@@ -111,7 +111,9 @@ function buildAsuRequest(request_hash) {
   var body = JSON.stringify({
     profile: current_device.id,
     target: current_device.target,
-    packages: split($("#asu-packages").value),
+    packages: split(
+      $("#asu-device-packages").value + " " + $("#asu-default-packages").value
+    ),
     defaults: $("#uci-defaults-content").value,
     version_code: $("#image-code").innerText,
     version: $("#versions").value,
@@ -642,8 +644,8 @@ function updateImages(mobj) {
       hide("#asu-log");
       hide("#asu-buildstatus");
       // Pre-select ASU packages.
-      $("#asu-packages").value = mobj.default_packages
-        .concat(mobj.device_packages)
+      $("#asu-device-packages").value = mobj.device_packages.join(" ");
+      $("#asu-default-packages").value = mobj.default_packages
         .concat(config.asu_extra_packages || [])
         .join(" ");
     }


### PR DESCRIPTION
Use separate fields for the device and default packages. This is meant to improve attention to what packages might brick the device.