### PR TITLE
index.js: include upcoming_version when adding snapshots

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -837,12 +837,12 @@ async function init() {
           }) >= 0
       );
 
-      if (config.show_snapshots) {
-        insertSnapshotVersions(versions);
-      }
-
       if (config.upcoming_version != "") {
         versions.push(obj.upcoming_version);
+      }
+
+      if (config.show_snapshots) {
+        insertSnapshotVersions(versions);
       }
 
       return {


### PR DESCRIPTION
Order of operations was ignoring the upcoming version when adding '*-SNAPSHOT' versions.  Make sure to put the upcoming version into the versions list before we add snapshots.

Links: https://github.com/openwrt/firmware-selector-openwrt-org/issues/7#issuecomment-2506683352