### PR TITLE
index.js: fix showing upcoming versions

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -837,7 +837,7 @@ async function init() {
           }) >= 0
       );
 
-      if (config.upcoming_version != "") {
+      if (config.upcoming_version) {
         versions.push(obj.upcoming_version);
       }
 


### PR DESCRIPTION
config.upcoming_version can be `null` instead of empty string.

Fixes: ec497140595f ("show upcomming versions below SNAPSHOTS")