### PR TITLE
improved error handling

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -154,7 +154,7 @@
                   </div>
                 </div>
                 <div>
-                  <h5 class="tr-packages">Installed Packages</h5>
+                  <h4 class="tr-packages">Installed Packages</h4>
                   <textarea
                     rows="10"
                     id="asu-packages"
@@ -163,9 +163,9 @@
                     autocapitalize="off"
                   ></textarea>
                 </div>
-                <h5 class="tr-defaults">
+                <h4 class="tr-defaults">
                   Script to run on first boot (uci-defaults)
-                </h5>
+                </h4>
                 <div id="uci-defaults-group">
                   <textarea
                     rows="10"

--- a/www/index.js
+++ b/www/index.js
@@ -104,7 +104,7 @@ function buildAsuRequest(request_hash) {
   }
 
   if (!current_device || !current_device.id) {
-    showStatus("bad profile");
+    showStatus("bad profile", false, "error");
     return;
   }
 
@@ -188,9 +188,7 @@ function buildAsuRequest(request_hash) {
           break;
       }
     })
-    .catch((err) => {
-      showStatus(err, false, "error");
-    });
+    .catch((err) => showStatus(err.message, false, "error"));
 }
 
 function setupSelectList(select, items, onselection) {
@@ -852,6 +850,11 @@ async function init() {
       };
     })
     .catch((err) => showAlert(err.message));
+
+  if (!upstream_config) {
+    // prevent further errors
+    return;
+  }
 
   if (!config.versions) {
     config.versions = upstream_config.versions;


### PR DESCRIPTION
Currently, some network errors are not displayed properly and instead make the interface just appear to freeze.
One example is when the ASU server returns empty data that is not valid JSON.

A second commit increases the size of the package list and uci-command window title.
 