### PR TITLE
index.js: handle all non-200 requests as errors

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -165,9 +165,7 @@ function buildAsuRequest(request_hash) {
             setTimeout(buildAsuRequest.bind(null, mobj.request_hash), 5000);
           });
           break;
-        case 400: // bad request
-        case 422: // bad package
-        case 500: // build failed
+        default: // Anything else is considered an error.
           response.json().then((mobj) => {
             if ("stderr" in mobj) {
               $("#asu-stderr").innerText = mobj.stderr;


### PR DESCRIPTION
We were selectively handling only a subset of responses explicitly as errors (400, 422 and 500); any other error status would be silently ignored.

Change the handler to consider anything other than 200 or 202 as an error response and produce some output for the user.

Link: https://github.com/openwrt/firmware-selector-openwrt-org/issues/99#issuecomment-3288565545