### PR TITLE
uci-defaults: add CIDR to lan address

### DIFF
--- a/www/uci-defaults/setup.sh
+++ b/www/uci-defaults/setup.sh
@@ -5,7 +5,12 @@
 # wlan_password="12345678"
 #
 # root_password=""
+#
+# For 24.10 and earlier, the 'netmask' will default to '255.255.255.0':
 # lan_ip_address="192.168.1.1"
+#
+# But, make sure to use CIDR notation for 25.12 and later:
+# lan_ip_address="192.168.1.1/24"
 #
 # pppoe_username=""
 # pppoe_password=""


### PR DESCRIPTION
Lack of address mask and missing CIDR breaks the network config, resulting in lock up of interfaces.

Link: https://forum.openwrt.org/t/the-uci-is-killing-the-comfast-cf-wr632ax/245611