### PR TITLE
package-defaults: include luci-app-attendedsysupgrade

### DIFF
--- a/www/config.js
+++ b/www/config.js
@@ -21,5 +21,5 @@ var config = {
 
   // Attended Sysupgrade Server support (optional)
   asu_url: "https://sysupgrade.openwrt.org",
-  asu_extra_packages: ["luci"],
+  asu_extra_packages: ["luci", "luci-app-attendedsysupgrade"],
 };


### PR DESCRIPTION
Users are expecting that the default build will include the same packages that are delivered in images from the downloads site. This expectation is being violated when the defaults do not include luci-app-attendedsysupgrade, so include it.

Link: https://forum.openwrt.org/t/the-openwrt-firmware-selector/81721/1628
Fixes: https://github.com/openwrt/openwrt/issues/22395