### PR TITLE
images.js: add feature to configure device-specific packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ If the option is not available (OpenWrt 18.06 or 19.07.3), apply commit [openwrt
 
 [ASU](https://github.com/openwrt/asu) is a build server that builds OpenWrt images with a given list of packages on request. The firmware-selector can be used as an interface to send these requests and to download the images when finished.
 
+### Optional extra packages per device (ASU)
+
+At startup the selector requests `device_packages.json` next to the app (under `www/`). If the file is missing or invalid, it is ignored. The JSON object maps **device profile IDs** (the same strings as in OpenWrt’s `profiles.json`, usually `vendor,model`) to a list of extra package names. Those packages are appended when the ASU package field is prefilled, after the image’s default packages, profile `device_packages`, and `asu_extra_packages` from `config.js`.
+
+Copy [`www/device_packages.json.example`](www/device_packages.json.example) to `www/device_packages.json` and adjust it for your deployment. Keys may use either comma or underscore as the first separator; the code tries both so `tplink,archer-c7-v5` and `tplink_archer-c7-v5` can match the same entry depending on how the ID is spelled.
+
 ### UCI-Defaults
 
 The Firmware Selector allows to define a script to be placed in the `/etc/uci-defaults/` folder of the OpenWrt image. These scripts are executed once on the first reboot and then deleted. See the [OpenWrt documentation](https://openwrt.org/docs/guide-developer/uci-defaults) on this topic.

--- a/tests/js/images.test.js
+++ b/tests/js/images.test.js
@@ -8,6 +8,8 @@ import {
   isAnyDeviceSelected,
   commonPrefix,
   getNameDifference,
+  normalizePackageList,
+  buildAsuPackages,
 } from "../../www/js/images.js";
 
 describe("getModelTitles", () => {
@@ -302,6 +304,63 @@ describe("sortImages", () => {
     const sorted = sortImages(images);
     assert.equal(sorted[0].type, "rootfs");
     assert.equal(sorted[1].type, "kernel");
+  });
+});
+
+describe("normalizePackageList", () => {
+  it("keeps only string entries", () => {
+    assert.deepEqual(
+      normalizePackageList(["a", 1, null, "b"]),
+      ["a", "b"]
+    );
+  });
+
+  it("returns empty array for non-array", () => {
+    assert.deepEqual(normalizePackageList(undefined), []);
+    assert.deepEqual(normalizePackageList({}), []);
+  });
+});
+
+describe("buildAsuPackages", () => {
+  it("merges profile, extras, and device_packages.json map", () => {
+    const pkgs = buildAsuPackages(
+      {
+        id: "dev,id",
+        default_packages: ["base"],
+        device_packages: ["kmod-x"],
+      },
+      {
+        asu_extra_packages: ["luci"],
+      },
+      { "dev,id": ["from-json"] }
+    );
+    assert.deepEqual(pkgs, ["base", "kmod-x", "luci", "from-json"]);
+  });
+
+  it("matches json map key with underscore when profile id uses comma", () => {
+    const pkgs = buildAsuPackages(
+      {
+        id: "vendor,model",
+        default_packages: [],
+        device_packages: [],
+      },
+      {},
+      { vendor_model: ["pkg-a"] }
+    );
+    assert.deepEqual(pkgs, ["pkg-a"]);
+  });
+
+  it("matches json map key with comma when profile id uses underscore", () => {
+    const pkgs = buildAsuPackages(
+      {
+        id: "vendor_model",
+        default_packages: [],
+        device_packages: [],
+      },
+      {},
+      { "vendor,model": ["pkg-b"] }
+    );
+    assert.deepEqual(pkgs, ["pkg-b"]);
   });
 });
 

--- a/www/device_packages.json.example
+++ b/www/device_packages.json.example
@@ -1,0 +1,4 @@
+{
+  "glinet,gl-mt3000": ["luci-app-wireguard", "wireguard-tools"],
+  "tplink,archer-c7-v5": ["luci-app-sqm", "sqm-scripts"]
+}

--- a/www/js/images.js
+++ b/www/js/images.js
@@ -122,8 +122,49 @@ export function isAnyDeviceSelected(currentDevice) {
   return Object.keys(currentDevice).length > 0;
 }
 
+export function normalizePackageList(list) {
+  return Array.isArray(list)
+    ? list.filter((pkg) => typeof pkg === "string")
+    : [];
+}
+
+function getMappedPackagesForDevice(deviceMap, deviceId) {
+  if (!deviceId) {
+    return [];
+  }
+
+  const idsToTry = [deviceId];
+  if (deviceId.includes("_")) {
+    idsToTry.push(deviceId.replace("_", ","));
+  }
+  if (deviceId.includes(",")) {
+    idsToTry.push(deviceId.replace(",", "_"));
+  }
+
+  for (const candidate of idsToTry) {
+    if (candidate in deviceMap) {
+      const v = deviceMap[candidate];
+      return Array.isArray(v) ? v : [];
+    }
+  }
+
+  return [];
+}
+
+export function buildAsuPackages(mobj, config, customDevicePackages) {
+  const jsonMap = customDevicePackages || {};
+  return normalizePackageList(
+    [].concat(
+      mobj.default_packages || [],
+      mobj.device_packages || [],
+      config.asu_extra_packages || [],
+      getMappedPackagesForDevice(jsonMap, mobj.id)
+    )
+  );
+}
+
 export function updateImages(version, mobj, context) {
-  const { config, currentDevice } = context;
+  const { config, currentDevice, customDevicePackages } = context;
 
   $$("#download-table1 *").forEach((e) => e.remove());
   $$("#download-links2 *").forEach((e) => e.remove());
@@ -214,10 +255,11 @@ export function updateImages(version, mobj, context) {
       $("#asu").open = false;
       hide("#asu-log");
       hide("#asu-buildstatus");
-      $("#asu-packages").value = mobj.default_packages
-        .concat(mobj.device_packages)
-        .concat(config.asu_extra_packages || [])
-        .join(" ");
+      $("#asu-packages").value = buildAsuPackages(
+        mobj,
+        config,
+        customDevicePackages
+      ).join(" ");
     }
 
     translate();

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -13,6 +13,7 @@ import {
 
 let currentDevice = {};
 let urlParams;
+let customDevicePackages = {};
 const ofsVersion = "%GIT_VERSION%";
 const progress = {
   "tr-init": 5,
@@ -36,6 +37,7 @@ function updateImagesBound(version, mobj) {
   return updateImages(version, mobj, {
     config,
     currentDevice,
+    customDevicePackages,
   });
 }
 
@@ -54,6 +56,12 @@ async function init() {
   if (typeof config.asu_url !== "undefined") {
     show("#asu");
   }
+
+  customDevicePackages = await fetch("device_packages.json", {
+    cache: "no-cache",
+  })
+    .then((obj) => (obj.status === 200 ? obj.json() : {}))
+    .catch(() => ({}));
 
   const upstreamConfig = await fetch(config.image_url + "/.versions.json", {
     cache: "no-cache",


### PR DESCRIPTION
this adds the following feature:

device-specific packages can be configured on the server with a json file like this

```
{
  "glinet,gl-mt3000": ["luci-app-wireguard", "wireguard-tools"],
  "tplink,archer-c7-v5": ["luci-app-sqm", "sqm-scripts"]
}
```