### PR TITLE
asu.js: allow to add additional repositories to asu build request

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ If the option is not available (OpenWrt 18.06 or 19.07.3), apply commit [openwrt
 
 [ASU](https://github.com/openwrt/asu) is a build server that builds OpenWrt images with a given list of packages on request. The firmware-selector can be used as an interface to send these requests and to download the images when finished.
 
+### Optional extra package repositories (ASU)
+
+Additional package feeds can be configured via `config.js` and are sent with each ASU build request:
+
+* `asu_repositories`: Object map of repository names to URLs.
+* `asu_repositories_mode`: Optional mode (`append` or `replace`).
+* `asu_repository_keys`: Optional list of repository signing keys.
+
+Repository URLs can use placeholders which are resolved per selected device/version:
+
+* `{openwrt_branch}` (for example `24.10`)
+* `{openwrt_version}` (for example `24.10.3`)
+* `{target}` (for example `ramips`)
+* `{subtarget}` (for example `mt7621`)
+
 ### Optional extra packages per device (ASU)
 
 At startup the selector requests `device_packages.json` next to the app (under `www/`). If the file is missing or invalid, it is ignored. The JSON object maps **device profile IDs** (the same strings as in OpenWrt’s `profiles.json`, usually `vendor,model`) to a list of extra package names. Those packages are appended when the ASU package field is prefilled, after the image’s default packages, profile `device_packages`, and `asu_extra_packages` from `config.js`.

--- a/tests/js/asu.test.js
+++ b/tests/js/asu.test.js
@@ -1,4 +1,4 @@
-import "./setup.js";
+import { mockElement } from "./setup.js";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { createAsuRequestBuilder } from "../../www/js/asu.js";
@@ -128,6 +128,75 @@ describe("createAsuRequestBuilder", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     assert.equal(capturedBody.client, "ofs/2.5.0");
+  });
+
+  it("includes resolved custom repositories and keys in request body", async () => {
+    let capturedBody;
+    const previousQuerySelector = document._qsImpl;
+    const select = mockElement({ value: "23.05.4" });
+    const qsMap = {
+      "#versions": select,
+    };
+    document._qsImpl = (selector) => qsMap[selector] || mockElement();
+
+    globalThis.fetch = fetchWithLangStub((_url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({ version_number: "23.05.4", bin_dir: "d" }),
+      });
+    });
+
+    const build = createAsuRequestBuilder(
+      makeContext({
+        config: {
+          asu_url: "http://asu.example.com",
+          asu_repositories: {
+            custom:
+              "https://repo.example/{openwrt_branch}/{openwrt_version}/{target}/{subtarget}",
+          },
+          asu_repository_keys: ["pubkey-1"],
+          asu_repositories_mode: "append",
+        },
+        getCurrentDevice: () => ({ id: "dev", target: "ramips/mt7621" }),
+      })
+    );
+    build();
+    await new Promise((r) => setTimeout(r, 50));
+    document._qsImpl = previousQuerySelector;
+
+    assert.deepEqual(capturedBody.repositories, {
+      custom: "https://repo.example/23.05/23.05.4/ramips/mt7621",
+    });
+    assert.deepEqual(capturedBody.repository_keys, ["pubkey-1"]);
+    assert.equal(capturedBody.repositories_mode, "append");
+  });
+
+  it("sends empty repositories_mode for unsupported mode values", async () => {
+    let capturedBody;
+    globalThis.fetch = fetchWithLangStub((_url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return Promise.resolve({
+        status: 200,
+        json: () =>
+          Promise.resolve({ version_number: "23.05.4", bin_dir: "d" }),
+      });
+    });
+
+    const build = createAsuRequestBuilder(
+      makeContext({
+        config: {
+          asu_url: "http://asu.example.com",
+          asu_repositories_mode: "unsupported",
+        },
+        getCurrentDevice: () => ({ id: "dev", target: "ramips/mt7621" }),
+      })
+    );
+    build();
+    await new Promise((r) => setTimeout(r, 50));
+
+    assert.equal(capturedBody.repositories_mode, "");
   });
 
   it("sends GET with hash appended when requestHash is provided", async () => {

--- a/www/config.js
+++ b/www/config.js
@@ -22,4 +22,12 @@ var config = {
   // Attended Sysupgrade Server support (optional)
   asu_url: "https://sysupgrade.openwrt.org",
   asu_extra_packages: ["luci", "luci-app-attendedsysupgrade"],
+  // Additional repositories for ASU build requests (optional)
+  // asu_repositories: {
+  //   my_feed: "https://example.com/packages/{openwrt_branch}/{target}/{subtarget}",
+  // },
+  // asu_repositories_mode: "append", // "append" or "replace"
+  // asu_repository_keys: [
+  //   "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----",
+  // ],
 };

--- a/www/js/asu.js
+++ b/www/js/asu.js
@@ -5,6 +5,34 @@ export function createAsuRequestBuilder(context) {
   const { config, progress, ofsVersion, getCurrentDevice, updateImages } =
     context;
 
+  function getOpenwrtBranch(openwrtVersion) {
+    const match = String(openwrtVersion || "").match(/^(\d+\.\d+)/);
+    return match ? match[1] : String(openwrtVersion || "");
+  }
+
+  function resolveAsuRepositories(
+    rawRepositories,
+    currentDevice,
+    openwrtVersion
+  ) {
+    const repositories = rawRepositories || {};
+    const [target = "", subtarget = ""] = String(
+      currentDevice?.target || ""
+    ).split("/");
+    const openwrtBranch = getOpenwrtBranch(openwrtVersion);
+
+    return Object.fromEntries(
+      Object.entries(repositories).map(([name, url]) => [
+        name,
+        String(url)
+          .replaceAll("{openwrt_branch}", openwrtBranch)
+          .replaceAll("{openwrt_version}", String(openwrtVersion || ""))
+          .replaceAll("{target}", target)
+          .replaceAll("{subtarget}", subtarget),
+      ])
+    );
+  }
+
   function showStatus(message, loading, type) {
     const bs = $("#asu-buildstatus");
     switch (type) {
@@ -47,32 +75,37 @@ export function createAsuRequestBuilder(context) {
       return;
     }
 
-    let requestUrl = `${config.asu_url}/api/v1/build`;
-    let body = JSON.stringify({
+    const selectedVersion = $("#versions").value;
+    const reposMode = config.asu_repositories_mode;
+    const repositoriesMode =
+      reposMode === "replace" || reposMode === "append" ? reposMode : "";
+    const buildBody = {
       profile: currentDevice.id,
       target: currentDevice.target,
       packages: split($("#asu-packages").value),
       defaults: $("#uci-defaults-content").value,
       version_code: $("#image-code").innerText,
-      version: $("#versions").value,
+      version: selectedVersion,
       diff_packages: true,
       client: "ofs/" + ofsVersion,
-    });
-    let method = "POST";
-
-    if (requestHash) {
-      requestUrl += `/${requestHash}`;
-      body = null;
-      method = "GET";
-    }
+      repositories: resolveAsuRepositories(
+        config.asu_repositories,
+        currentDevice,
+        selectedVersion
+      ),
+      repository_keys: config.asu_repository_keys || [],
+      repositories_mode: repositoriesMode,
+    };
+    const requestUrl =
+      `${config.asu_url}/api/v1/build` + (requestHash ? `/${requestHash}` : "");
 
     fetch(requestUrl, {
       cache: "no-cache",
-      method: method,
+      method: requestHash ? "GET" : "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: body,
+      body: requestHash ? null : JSON.stringify(buildBody),
     })
       .then((response) => {
         switch (response.status) {


### PR DESCRIPTION
with this feature we can:

* add additional repos to asu builds
* supports `append` or `replace` mode added in https://github.com/openwrt/asu/pull/1602
* repo urls can be templated with openwrt_version, openwrt_series, target and subtarget