### PR TITLE
images: show help text/hash in mobile view

### DIFF
--- a/www/js/images.js
+++ b/www/js/images.js
@@ -222,6 +222,7 @@ export function updateImages(version, mobj, context) {
     const links2 = $("#download-links2");
     const extras2 = $("#download-extras2");
 
+    // populate desktop view
     for (const image of sortImages(mobj.images)) {
       const link = createLink(mobj, image, mobj.image_folder);
       const extra = createExtra(image, config);
@@ -231,6 +232,7 @@ export function updateImages(version, mobj, context) {
       row.appendChild(extra);
     }
 
+    // populate mobile view
     for (const image of sortImages(mobj.images)) {
       const link = createLink(mobj, image, mobj.image_folder);
       const extra = createExtra(image, config);

--- a/www/js/images.js
+++ b/www/js/images.js
@@ -249,7 +249,7 @@ export function updateImages(version, mobj, context) {
         link.firstChild.classList.add("download-link-hover");
 
         extras2.childNodes.forEach((e) => hide(e));
-        hide(extra);
+        show(extra);
       };
     }
 


### PR DESCRIPTION
The element for the help text and hash value
is meant to be shown on mouse over event.

This MR fixes the bug reported in #177