### PR TITLE
www/css: fix HiDPI mobile layout bug and modernize CSS

### DIFF
--- a/www/index.css
+++ b/www/index.css
@@ -3,7 +3,7 @@ html {
 }
 
 /* adjust for mobile view */
-@media (min-resolution: 400dpi), (max-width: 600px), (pointer: coarse) {
+@media (max-width: 600px), (pointer: coarse) {
   #models-autocomplete {
     /* move version selection in a new line */
     flex-direction: column !important;
@@ -194,14 +194,14 @@ header > div {
   font-weight: 400;
   line-height: 1.3;
   vertical-align: middle;
-  word-wrap: anywhere;
+  overflow-wrap: anywhere;
 }
 
 .hash-content {
   font-size: 0.8rem;
   letter-spacing: 0.1em;
   padding-top: 0.4em;
-  word-wrap: anywhere;
+  overflow-wrap: anywhere;
 }
 
 .download-link {
@@ -357,8 +357,8 @@ header > div {
 #uci-defaults-content,
 #uci-defaults-group {
   resize: none;
-  width: -moz-available;
-  width: -webkit-fill-available;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 #uci-defaults-group {


### PR DESCRIPTION
Drop the min-resolution: 400dpi condition from the mobile media query
in index.css. It is redundant: real ~400dpi (4.2dppx) devices are
phones and tablets that already match pointer: coarse, while desktop
HiDPI and 4K displays run around 2dppx (192dpi) and never matched it.
High browser zoom shrinks the CSS viewport and is already covered by
the max-width: 600px condition.

Replace non-standard -moz-available and -webkit-fill-available with
standard width: 100% and box-sizing: border-box for textareas. Update
word-wrap to its standard name overflow-wrap.