### PR TITLE
www/js: fix array sort comparator and ASU status updates

### DIFF
--- a/www/js/asu.js
+++ b/www/js/asu.js
@@ -110,7 +110,6 @@ export function createAsuRequestBuilder(context) {
       .then((response) => {
         switch (response.status) {
           case 200:
-            showStatus("tr-build-successful", false, "info");
             response.json().then((mobj) => {
               if ("stderr" in mobj) {
                 $("#asu-stderr").innerText = mobj.stderr;
@@ -133,9 +132,9 @@ export function createAsuRequestBuilder(context) {
                 "info"
               );
               if (mobj.queue_position) {
-                $(
-                  "#asu-buildstatus span"
-                ).innerText += ` (${mobj.queue_position})`;
+                $("#asu-buildstatus span").appendChild(
+                  document.createTextNode(` (${mobj.queue_position})`)
+                );
               }
               setTimeout(buildAsuRequest.bind(null, mobj.request_hash), 5000);
             });

--- a/www/js/autocomplete.js
+++ b/www/js/autocomplete.js
@@ -9,7 +9,7 @@ export function match(value, patterns) {
     matches.push({ begin: i, length: p.length });
   }
 
-  matches.sort((a, b) => a.begin > b.begin);
+  matches.sort((a, b) => a.begin - b.begin);
 
   let prev = null;
   const ranges = [];


### PR DESCRIPTION
Fix Array.prototype.sort() comparator in autocomplete.js to return a numeric difference (a.begin - b.begin) instead of a boolean value, which never reports "less than" and produces wrong match ordering.

In asu.js, append the queue position as a text node next to the status span instead of reassigning innerText on the parent element, which replaced all children and destroyed the progress bar. A sibling text node also survives translate(), which rewrites the inner status span based on its tr-* class, and keeps the progress map lookup keyed by the clean status name. Also remove the duplicate showStatus() call on HTTP 200.