### PR TITLE
www/js: modernize keyboard events and cleanup code

### DIFF
--- a/www/js/autocomplete.js
+++ b/www/js/autocomplete.js
@@ -95,13 +95,13 @@ export function setupAutocompleteList(input, items, onbegin, onend) {
   input.onkeydown = function (e) {
     let x = document.getElementById(this.id + "-autocomplete-list");
     if (x) x = x.getElementsByTagName("div");
-    if (e.keyCode === 40) {
+    if (e.key === "ArrowDown" || e.keyCode === 40) {
       currentFocus += 1;
       setActive(x);
-    } else if (e.keyCode === 38) {
+    } else if (e.key === "ArrowUp" || e.keyCode === 38) {
       currentFocus -= 1;
       setActive(x);
-    } else if (e.keyCode === 13) {
+    } else if (e.key === "Enter" || e.keyCode === 13) {
       e.preventDefault();
       if (currentFocus > -1) {
         if (x) x[currentFocus].click();

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -120,8 +120,6 @@ async function init() {
     }
   }
 
-  console.log("versions: " + config.versions);
-
   setupSelectList(
     $("#versions"),
     config.versions,


### PR DESCRIPTION
Update keyboard event handling in autocomplete.js to check e.key (ArrowDown, ArrowUp, Enter) alongside legacy e.keyCode.

Remove leftover debug console.log from main.js.

The var declaration in config.js is intentionally left as-is: config.js is loaded as a classic script and main.js reads window.config, which a top-level const or let would not define.